### PR TITLE
Add core D&D 3.5 character calculations and models

### DIFF
--- a/Components/ACBlock.razor
+++ b/Components/ACBlock.razor
@@ -1,0 +1,17 @@
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.RulesService Rules
+
+@if (Character != null)
+{
+    var ac = Rules.ArmorClass(Character);
+    <div class="ac">
+        <div>AC: @ac.Total</div>
+        <div>Touch: @ac.Touch</div>
+        <div>Flat-Footed: @ac.FlatFooted</div>
+        <div>DEX Used: @ac.DexUsed</div>
+    </div>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/AbilitiesCard.razor
+++ b/Components/AbilitiesCard.razor
@@ -1,0 +1,21 @@
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.RulesService Rules
+
+<div class="abilities">
+@foreach (var ability in Enum.GetValues<Ability>())
+{
+    <div class="ability-row">
+        <label>@ability.ToString().ToUpper()</label>
+        <input type="number" value="@Abilities[ability]" @onchange="e => Update(ability, e)" />
+        <span>@Rules.AbilityMod(Abilities[ability] + TempMods[ability])</span>
+    </div>
+}
+</div>
+
+@code {
+    [Parameter] public AbilityScores Abilities { get; set; } = new();
+    [Parameter] public AbilityScores TempMods { get; set; } = new();
+
+    private void Update(Ability ability, ChangeEventArgs e)
+        => Abilities[ability] = int.Parse(e.Value?.ToString() ?? "0");
+}

--- a/Components/InventoryPanel.razor
+++ b/Components/InventoryPanel.razor
@@ -1,0 +1,15 @@
+@using dnd3._5App.Models
+
+@if (Character != null)
+{
+    <ul>
+    @foreach (var item in Character.Inventory)
+    {
+        <li>@item.Name x@item.Qty (@item.Weight lb)</li>
+    }
+    </ul>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/MoneyPanel.razor
+++ b/Components/MoneyPanel.razor
@@ -1,0 +1,15 @@
+@using dnd3._5App.Models
+
+@if (Character != null)
+{
+    <div class="money">
+        <div>CP: @Character.Money.Cp</div>
+        <div>SP: @Character.Money.Sp</div>
+        <div>GP: @Character.Money.Gp</div>
+        <div>PP: @Character.Money.Pp</div>
+    </div>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/SavesCard.razor
+++ b/Components/SavesCard.razor
@@ -1,0 +1,16 @@
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.RulesService Rules
+
+@if (Character != null)
+{
+    var saves = Rules.Saves(Character);
+    <div class="saves">
+        <div>Fortitude: @saves.Fort</div>
+        <div>Reflex: @saves.Ref</div>
+        <div>Will: @saves.Will</div>
+    </div>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/SkillsTable.razor
+++ b/Components/SkillsTable.razor
@@ -1,0 +1,23 @@
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.RulesService Rules
+
+@if (Character != null)
+{
+    <table class="skills">
+        <thead><tr><th>Skill</th><th>Total</th><th>Ranks</th></tr></thead>
+        <tbody>
+        @foreach (var s in Character.Skills)
+        {
+            <tr>
+                <td>@s.Name</td>
+                <td>@Rules.SkillTotal(Character, s)</td>
+                <td>@s.Ranks</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/SpellsPanel.razor
+++ b/Components/SpellsPanel.razor
@@ -1,0 +1,21 @@
+@using dnd3._5App.Models
+
+@if (Character != null)
+{
+    foreach (var entry in Character.Spells.CasterEntries)
+    {
+        <div class="caster-entry">
+            <h4>@entry.ClassName</h4>
+            <ul>
+            @foreach (var spell in entry.Known)
+            {
+                <li>@spell.Name (Lv @spell.Level)</li>
+            }
+            </ul>
+        </div>
+    }
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Components/WeaponsTable.razor
+++ b/Components/WeaponsTable.razor
@@ -1,0 +1,24 @@
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.RulesService Rules
+
+@if (Character != null)
+{
+    var bab = Rules.BaseAttackBonus(Character);
+    <table class="weapons">
+        <thead><tr><th>Name</th><th>Bonus</th><th>Damage</th></tr></thead>
+        <tbody>
+        @foreach (var a in Character.Attacks)
+        {
+            <tr>
+                <td>@a.Name</td>
+                <td>@(bab + a.Enhancement + Rules.AbilityMod(Rules.AbilityScore(Character, Ability.Str)))</td>
+                <td>@a.Damage</td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Parameter] public Character? Character { get; set; }
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -20,6 +20,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="characters">
+                <span class="bi bi-people-fill-nav-menu" aria-hidden="true"></span> Characters
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="weather">
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>

--- a/Models/AbilityScores.cs
+++ b/Models/AbilityScores.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class AbilityScores
+{
+    [JsonPropertyName("str")] public int Str { get; set; } = 10;
+    [JsonPropertyName("dex")] public int Dex { get; set; } = 10;
+    [JsonPropertyName("con")] public int Con { get; set; } = 10;
+    [JsonPropertyName("int")] public int Int { get; set; } = 10;
+    [JsonPropertyName("wis")] public int Wis { get; set; } = 10;
+    [JsonPropertyName("cha")] public int Cha { get; set; } = 10;
+
+    public int this[Ability ability]
+    {
+        get => ability switch
+        {
+            Ability.Str => Str,
+            Ability.Dex => Dex,
+            Ability.Con => Con,
+            Ability.Int => Int,
+            Ability.Wis => Wis,
+            Ability.Cha => Cha,
+            _ => 0
+        };
+        set
+        {
+            switch (ability)
+            {
+                case Ability.Str: Str = value; break;
+                case Ability.Dex: Dex = value; break;
+                case Ability.Con: Con = value; break;
+                case Ability.Int: Int = value; break;
+                case Ability.Wis: Wis = value; break;
+                case Ability.Cha: Cha = value; break;
+            }
+        }
+    }
+}

--- a/Models/AcInfo.cs
+++ b/Models/AcInfo.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class AcInfo
+{
+    [JsonPropertyName("armorBonus")] public int ArmorBonus { get; set; } = 0;
+    [JsonPropertyName("shieldBonus")] public int ShieldBonus { get; set; } = 0;
+    [JsonPropertyName("naturalArmor")] public int NaturalArmor { get; set; } = 0;
+    [JsonPropertyName("deflection")] public int Deflection { get; set; } = 0;
+    [JsonPropertyName("dodge")] public int Dodge { get; set; } = 0;
+    [JsonPropertyName("misc")] public int Misc { get; set; } = 0;
+    [JsonPropertyName("armorCheckPenalty")] public int ArmorCheckPenalty { get; set; } = 0;
+    [JsonPropertyName("maxDex")] public int? MaxDex { get; set; }
+}

--- a/Models/Attack.cs
+++ b/Models/Attack.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Attack
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("weapon")] public string Weapon { get; set; } = string.Empty;
+    [JsonPropertyName("enhancement")] public int Enhancement { get; set; } = 0;
+    [JsonPropertyName("damage")] public string Damage { get; set; } = string.Empty;
+    [JsonPropertyName("crit")] public string Crit { get; set; } = string.Empty;
+    [JsonPropertyName("rangeIncrement")] public int? RangeIncrement { get; set; }
+}

--- a/Models/Character.cs
+++ b/Models/Character.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Character
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = Guid.NewGuid().ToString();
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("race")] public string Race { get; set; } = string.Empty;
+    [JsonPropertyName("classLevels")] public List<ClassLevel> ClassLevels { get; set; } = new();
+    [JsonPropertyName("alignment")] public string Alignment { get; set; } = string.Empty;
+    [JsonPropertyName("size")] public SizeCategory Size { get; set; } = SizeCategory.Medium;
+    [JsonPropertyName("deity")] public string? Deity { get; set; } = string.Empty;
+
+    [JsonPropertyName("speedBase")] public int SpeedBase { get; set; } = 30;
+    [JsonPropertyName("abilities")] public AbilityScores Abilities { get; set; } = new();
+    [JsonPropertyName("abilityTempMods")] public AbilityScores AbilityTempMods { get; set; } = new();
+    [JsonPropertyName("hp")] public HpInfo Hp { get; set; } = new();
+    [JsonPropertyName("ac")] public AcInfo Ac { get; set; } = new();
+    [JsonPropertyName("initiativeMisc")] public int InitiativeMisc { get; set; } = 0;
+    [JsonPropertyName("savesMisc")] public SavesMisc SavesMisc { get; set; } = new();
+    [JsonPropertyName("attacks")] public List<Attack> Attacks { get; set; } = new();
+    [JsonPropertyName("grappleMisc")] public int GrappleMisc { get; set; } = 0;
+    [JsonPropertyName("skills")] public List<Skill> Skills { get; set; } = new();
+    [JsonPropertyName("feats")] public List<Feat> Feats { get; set; } = new();
+    [JsonPropertyName("traits")] public List<string> Traits { get; set; } = new();
+    [JsonPropertyName("classFeatures")] public List<ClassFeature> ClassFeatures { get; set; } = new();
+    [JsonPropertyName("languages")] public List<string> Languages { get; set; } = new();
+    [JsonPropertyName("equipment")] public List<EquipmentItem> Equipment { get; set; } = new();
+    [JsonPropertyName("inventory")] public List<InventoryItem> Inventory { get; set; } = new();
+    [JsonPropertyName("money")] public Money Money { get; set; } = new();
+    [JsonPropertyName("encumbrance")] public Encumbrance Encumbrance { get; set; } = new();
+    [JsonPropertyName("spells")] public SpellsInfo Spells { get; set; } = new();
+    [JsonPropertyName("notes")] public string Notes { get; set; } = string.Empty;
+
+    [JsonIgnore]
+    public int Level => ClassLevels.Sum(c => c.Level);
+}

--- a/Models/ClassFeature.cs
+++ b/Models/ClassFeature.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class ClassFeature
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("uses")] public int Uses { get; set; } = 0;
+    [JsonPropertyName("notes")] public string Notes { get; set; } = string.Empty;
+}

--- a/Models/ClassLevel.cs
+++ b/Models/ClassLevel.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class SaveProgressionSet
+{
+    [JsonPropertyName("fort")] public SaveProgression Fort { get; set; } = SaveProgression.Poor;
+    [JsonPropertyName("ref")] public SaveProgression Ref { get; set; } = SaveProgression.Poor;
+    [JsonPropertyName("will")] public SaveProgression Will { get; set; } = SaveProgression.Poor;
+}
+
+public class ClassLevel
+{
+    [JsonPropertyName("className")] public string ClassName { get; set; } = string.Empty;
+    [JsonPropertyName("level")] public int Level { get; set; } = 1;
+    [JsonPropertyName("babProgression")] public BabProgression BabProgression { get; set; } = BabProgression.Full;
+    [JsonPropertyName("saveProgression")] public SaveProgressionSet SaveProgression { get; set; } = new();
+}

--- a/Models/Encumbrance.cs
+++ b/Models/Encumbrance.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Encumbrance
+{
+    [JsonPropertyName("carryCapacityOverride")] public double? CarryCapacityOverride { get; set; }
+}

--- a/Models/Enums.cs
+++ b/Models/Enums.cs
@@ -1,0 +1,8 @@
+namespace dnd3._5App.Models;
+
+public enum BabProgression { Full, ThreeQuarter, Half }
+public enum SaveProgression { Good, Poor }
+public enum SizeCategory { Fine, Diminutive, Tiny, Small, Medium, Large, Huge, Gargantuan, Colossal }
+public enum Ability { Str, Dex, Con, Int, Wis, Cha }
+
+public enum LoadCategory { Light, Medium, Heavy, Overloaded }

--- a/Models/EquipmentItem.cs
+++ b/Models/EquipmentItem.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class EquipmentItem
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("qty")] public int Qty { get; set; } = 1;
+    [JsonPropertyName("weight")] public double Weight { get; set; } = 0;
+    [JsonPropertyName("slot")] public string Slot { get; set; } = string.Empty;
+    [JsonPropertyName("acBonus")] public int AcBonus { get; set; } = 0;
+    [JsonPropertyName("armorCheckPenalty")] public int ArmorCheckPenalty { get; set; } = 0;
+    [JsonPropertyName("maxDex")] public int? MaxDex { get; set; }
+}

--- a/Models/Feat.cs
+++ b/Models/Feat.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Feat
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("notes")] public string Notes { get; set; } = string.Empty;
+}

--- a/Models/HpInfo.cs
+++ b/Models/HpInfo.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class HpInfo
+{
+    [JsonPropertyName("rolled")] public List<int> Rolled { get; set; } = new();
+    [JsonPropertyName("bonusPerLevel")] public int BonusPerLevel { get; set; } = 0;
+    [JsonPropertyName("misc")] public int Misc { get; set; } = 0;
+    [JsonPropertyName("current")] public int Current { get; set; } = 0;
+    [JsonPropertyName("nonlethal")] public int Nonlethal { get; set; } = 0;
+}

--- a/Models/InventoryItem.cs
+++ b/Models/InventoryItem.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class InventoryItem
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("qty")] public int Qty { get; set; } = 1;
+    [JsonPropertyName("weight")] public double Weight { get; set; } = 0;
+}

--- a/Models/Money.cs
+++ b/Models/Money.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Money
+{
+    [JsonPropertyName("cp")] public int Cp { get; set; } = 0;
+    [JsonPropertyName("sp")] public int Sp { get; set; } = 0;
+    [JsonPropertyName("gp")] public int Gp { get; set; } = 0;
+    [JsonPropertyName("pp")] public int Pp { get; set; } = 0;
+}

--- a/Models/SavesMisc.cs
+++ b/Models/SavesMisc.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class SavesMisc
+{
+    [JsonPropertyName("fort")] public int Fort { get; set; } = 0;
+    [JsonPropertyName("ref")] public int Ref { get; set; } = 0;
+    [JsonPropertyName("will")] public int Will { get; set; } = 0;
+}

--- a/Models/Skill.cs
+++ b/Models/Skill.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Skill
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("ability")] public Ability Ability { get; set; } = Ability.Int;
+    [JsonPropertyName("ranks")] public double Ranks { get; set; } = 0;
+    [JsonPropertyName("misc")] public int Misc { get; set; } = 0;
+    [JsonPropertyName("armorCheckApplies")] public bool ArmorCheckApplies { get; set; } = false;
+    [JsonPropertyName("isClassSkill")] public bool IsClassSkill { get; set; } = true;
+}

--- a/Models/Spell.cs
+++ b/Models/Spell.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace dnd3._5App.Models;
+
+public class Spell
+{
+    [JsonPropertyName("name")] public string Name { get; set; } = string.Empty;
+    [JsonPropertyName("level")] public int Level { get; set; }
+    [JsonPropertyName("school")] public string School { get; set; } = string.Empty;
+    [JsonPropertyName("description")] public string Description { get; set; } = string.Empty;
+    [JsonPropertyName("castingTime")] public string CastingTime { get; set; } = string.Empty;
+    [JsonPropertyName("components")] public string Components { get; set; } = string.Empty;
+    [JsonPropertyName("range")] public string Range { get; set; } = string.Empty;
+    [JsonPropertyName("target")] public string Target { get; set; } = string.Empty;
+    [JsonPropertyName("duration")] public string Duration { get; set; } = string.Empty;
+    [JsonPropertyName("save")] public string Save { get; set; } = string.Empty;
+    [JsonPropertyName("sr")] public string Sr { get; set; } = string.Empty;
+    [JsonPropertyName("reference")] public string Reference { get; set; } = string.Empty;
+}
+
+public class PreparedSpell
+{
+    [JsonPropertyName("spellName")] public string SpellName { get; set; } = string.Empty;
+    [JsonPropertyName("level")] public int Level { get; set; }
+    [JsonPropertyName("count")] public int Count { get; set; } = 0;
+}
+
+public class CasterEntry
+{
+    [JsonPropertyName("className")] public string ClassName { get; set; } = string.Empty;
+    [JsonPropertyName("ability")] public Ability Ability { get; set; } = Ability.Int;
+    [JsonPropertyName("known")] public List<Spell> Known { get; set; } = new();
+    [JsonPropertyName("prepared")] public List<PreparedSpell> Prepared { get; set; } = new();
+    [JsonPropertyName("slots")] public Dictionary<int, int> Slots { get; set; } = new();
+}
+
+public class SpellsInfo
+{
+    [JsonPropertyName("casterEntries")] public List<CasterEntry> CasterEntries { get; set; } = new();
+}

--- a/Pages/Character.razor
+++ b/Pages/Character.razor
@@ -1,0 +1,32 @@
+@page "/character/{Id}"
+@using dnd3._5App.Models
+@using System.Linq
+@inject dnd3._5App.Services.StorageService Storage
+@inject dnd3._5App.Services.RulesService Rules
+
+@if (CurrentCharacter == null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <h2>@CurrentCharacter.Name</h2>
+    <AbilitiesCard Abilities="CurrentCharacter.Abilities" TempMods="CurrentCharacter.AbilityTempMods" />
+    <SavesCard Character="CurrentCharacter" />
+    <ACBlock Character="CurrentCharacter" />
+    <WeaponsTable Character="CurrentCharacter" />
+    <SkillsTable Character="CurrentCharacter" />
+    <SpellsPanel Character="CurrentCharacter" />
+    <InventoryPanel Character="CurrentCharacter" />
+    <MoneyPanel Character="CurrentCharacter" />
+}
+
+@code {
+    [Parameter] public string? Id { get; set; }
+    public dnd3._5App.Models.Character? CurrentCharacter { get; set; }
+    protected override async Task OnInitializedAsync()
+    {
+        var list = await Storage.GetCharactersAsync();
+        CurrentCharacter = list.FirstOrDefault(c => c.Id == Id);
+    }
+}

--- a/Pages/Characters.razor
+++ b/Pages/Characters.razor
@@ -1,0 +1,27 @@
+@page "/characters"
+@using dnd3._5App.Models
+@inject dnd3._5App.Services.StorageService Storage
+
+<h3>Characters</h3>
+
+@if (_characters is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <ul>
+    @foreach (var c in _characters)
+    {
+        <li><a href="/character/@c.Id">@c.Name (@c.Level)</a></li>
+    }
+    </ul>
+}
+
+@code {
+    private List<dnd3._5App.Models.Character>? _characters;
+    protected override async Task OnInitializedAsync()
+    {
+        _characters = await Storage.GetCharactersAsync();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,27 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using TG.Blazor.IndexedDB;
 using dnd3._5App;
+using dnd3._5App.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+
+builder.Services.AddIndexedDB(dbModel =>
+{
+    dbModel.DbName = "DnDApp";
+    dbModel.Version = 1;
+    dbModel.Stores.Add(new StoreSchema
+    {
+        Name = "characters",
+        PrimaryKey = new IndexSpec { Name = "id", KeyPath = "id", Auto = false }
+    });
+});
+
+builder.Services.AddScoped<StorageService>();
+builder.Services.AddScoped<RulesService>();
 
 await builder.Build().RunAsync();

--- a/Services/RulesService.cs
+++ b/Services/RulesService.cs
@@ -1,0 +1,124 @@
+using dnd3._5App.Models;
+
+namespace dnd3._5App.Services;
+
+/// <summary>
+/// Pure calculation helpers for D&D 3.5 rules.
+/// </summary>
+public class RulesService
+{
+    private static readonly Dictionary<SizeCategory, int> SizeGrappleMods = new()
+    {
+        [SizeCategory.Fine] = -16,
+        [SizeCategory.Diminutive] = -12,
+        [SizeCategory.Tiny] = -8,
+        [SizeCategory.Small] = -4,
+        [SizeCategory.Medium] = 0,
+        [SizeCategory.Large] = 4,
+        [SizeCategory.Huge] = 8,
+        [SizeCategory.Gargantuan] = 12,
+        [SizeCategory.Colossal] = 16
+    };
+
+    public int AbilityMod(int score) => (int)Math.Floor((score - 10) / 2.0);
+
+    public int AbilityScore(Character c, Ability ability) =>
+        c.Abilities[ability] + c.AbilityTempMods[ability];
+
+    public int BaseAttackBonus(Character c)
+    {
+        int total = 0;
+        foreach (var cl in c.ClassLevels)
+        {
+            total += cl.BabProgression switch
+            {
+                BabProgression.Full => cl.Level,
+                BabProgression.ThreeQuarter => (int)Math.Floor(cl.Level * 0.75),
+                BabProgression.Half => cl.Level / 2,
+                _ => 0
+            };
+        }
+        return total;
+    }
+
+    private int BaseSave(int level, SaveProgression prog) => prog switch
+    {
+        SaveProgression.Good => 2 + (level - 1) / 2,
+        SaveProgression.Poor => level / 3,
+        _ => 0
+    };
+
+    public (int Fort, int Ref, int Will) Saves(Character c)
+    {
+        int bFort = 0, bRef = 0, bWill = 0;
+        foreach (var cl in c.ClassLevels)
+        {
+            bFort += BaseSave(cl.Level, cl.SaveProgression.Fort);
+            bRef += BaseSave(cl.Level, cl.SaveProgression.Ref);
+            bWill += BaseSave(cl.Level, cl.SaveProgression.Will);
+        }
+        int fort = bFort + AbilityMod(AbilityScore(c, Ability.Con)) + c.SavesMisc.Fort;
+        int reflex = bRef + AbilityMod(AbilityScore(c, Ability.Dex)) + c.SavesMisc.Ref;
+        int will = bWill + AbilityMod(AbilityScore(c, Ability.Wis)) + c.SavesMisc.Will;
+        return (fort, reflex, will);
+    }
+
+    public int Grapple(Character c)
+    {
+        var sizeMod = SizeGrappleMods[c.Size];
+        return BaseAttackBonus(c) + AbilityMod(AbilityScore(c, Ability.Str)) + sizeMod + c.GrappleMisc;
+    }
+
+    public int Initiative(Character c) => AbilityMod(AbilityScore(c, Ability.Dex)) + c.InitiativeMisc;
+
+    public (int Total, int Touch, int FlatFooted, int DexUsed) ArmorClass(Character c)
+    {
+        int dexMod = AbilityMod(AbilityScore(c, Ability.Dex));
+        if (c.Ac.MaxDex.HasValue && dexMod > c.Ac.MaxDex.Value)
+            dexMod = c.Ac.MaxDex.Value;
+        int ac = 10 + dexMod + c.Ac.ArmorBonus + c.Ac.ShieldBonus + c.Ac.NaturalArmor + c.Ac.Deflection + c.Ac.Dodge + c.Ac.Misc;
+        int touch = 10 + dexMod + c.Ac.Deflection + c.Ac.Dodge + c.Ac.Misc;
+        int flat = 10 + c.Ac.ArmorBonus + c.Ac.ShieldBonus + c.Ac.NaturalArmor + c.Ac.Deflection + c.Ac.Misc;
+        return (ac, touch, flat, dexMod);
+    }
+
+    public int MaxHp(Character c)
+    {
+        int conMod = AbilityMod(AbilityScore(c, Ability.Con));
+        return c.Hp.Rolled.Sum() + conMod * c.Level + c.Hp.BonusPerLevel * c.Level + c.Hp.Misc;
+    }
+
+    public int SkillTotal(Character c, Skill skill)
+    {
+        double ranks = Math.Min(skill.Ranks, MaxRanks(c.Level, skill.IsClassSkill));
+        int total = (int)Math.Floor(ranks) + AbilityMod(AbilityScore(c, skill.Ability)) + skill.Misc;
+        if (skill.ArmorCheckApplies)
+            total += c.Ac.ArmorCheckPenalty;
+        return total;
+    }
+
+    public double MaxRanks(int level, bool isClassSkill) => isClassSkill ? level + 3 : (level + 3) / 2.0;
+
+    private static readonly int[] LightLoads =
+    {
+        0,3,6,10,13,16,20,23,26,30,33,38,43,50,58,66,76,86,100,116,133,153,173,200,233,266,306,346,400,466
+    };
+
+    public (double Light, double Medium, double Heavy) CarryCapacities(int str)
+    {
+        if (str < 1) str = 1;
+        if (str > 29) str = 29;
+        double light = LightLoads[str];
+        return (light, light * 2, light * 3);
+    }
+
+    public (LoadCategory Category, double Total, double Light, double Medium, double Heavy) Encumbrance(Character c)
+    {
+        double weight = c.Equipment.Sum(e => e.Weight * e.Qty) + c.Inventory.Sum(i => i.Weight * i.Qty);
+        var (light, medium, heavy) = CarryCapacities(AbilityScore(c, Ability.Str));
+        if (c.Encumbrance.CarryCapacityOverride.HasValue)
+            heavy = c.Encumbrance.CarryCapacityOverride.Value;
+        LoadCategory cat = weight <= light ? LoadCategory.Light : weight <= medium ? LoadCategory.Medium : weight <= heavy ? LoadCategory.Heavy : LoadCategory.Overloaded;
+        return (cat, weight, light, medium, heavy);
+    }
+}

--- a/Services/StorageService.cs
+++ b/Services/StorageService.cs
@@ -1,0 +1,59 @@
+using dnd3._5App.Models;
+using TG.Blazor.IndexedDB;
+using System.Linq;
+
+namespace dnd3._5App.Services;
+
+/// <summary>
+/// Simple wrapper around IndexedDB. Fallback to in-memory list when unavailable.
+/// </summary>
+public class StorageService
+{
+    private readonly IndexedDBManager _db;
+    private readonly List<Character> _memory = new();
+    private const string StoreName = "characters";
+
+    public StorageService(IndexedDBManager db)
+    {
+        _db = db;
+    }
+
+    public async Task<List<Character>> GetCharactersAsync()
+    {
+        try
+        {
+            var recs = await _db.GetRecords<Character>(StoreName);
+            return recs.ToList();
+        }
+        catch
+        {
+            return _memory;
+        }
+    }
+
+    public async Task SaveCharacterAsync(Character c)
+    {
+        try
+        {
+            var record = new StoreRecord<Character> { Storename = StoreName, Data = c };
+            await _db.AddRecord(record);
+        }
+        catch
+        {
+            var idx = _memory.FindIndex(x => x.Id == c.Id);
+            if (idx >= 0) _memory[idx] = c; else _memory.Add(c);
+        }
+    }
+
+    public async Task DeleteCharacterAsync(string id)
+    {
+        try
+        {
+            await _db.DeleteRecord(StoreName, id);
+        }
+        catch
+        {
+            _memory.RemoveAll(c => c.Id == id);
+        }
+    }
+}

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using dnd3._5App
 @using dnd3._5App.Layout
+@using dnd3._5App.Components

--- a/dnd3.5App.Tests/GlobalUsings.cs
+++ b/dnd3.5App.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/dnd3.5App.Tests/RulesServiceTests.cs
+++ b/dnd3.5App.Tests/RulesServiceTests.cs
@@ -1,0 +1,61 @@
+using dnd3._5App.Models;
+using dnd3._5App.Services;
+using Xunit;
+
+namespace dnd3._5App.Tests;
+
+public class RulesServiceTests
+{
+    private readonly RulesService _rules = new();
+
+    private Character CreateBaseCharacter()
+    {
+        return new Character
+        {
+            Abilities = new AbilityScores { Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10 },
+            AbilityTempMods = new AbilityScores { Str = 0, Dex = 0, Con = 0, Int = 0, Wis = 0, Cha = 0 },
+            ClassLevels = new List<ClassLevel> { new() { ClassName = "Fighter", Level = 3, BabProgression = BabProgression.Full, SaveProgression = new SaveProgressionSet { Fort = SaveProgression.Good, Ref = SaveProgression.Poor, Will = SaveProgression.Poor } } },
+            Skills = new List<Skill>(),
+            Equipment = new List<EquipmentItem>(),
+            Inventory = new List<InventoryItem>(),
+            Ac = new AcInfo()
+        };
+    }
+
+    [Fact]
+    public void AbilityMod_ComputesCorrectly()
+    {
+        Assert.Equal(4, _rules.AbilityMod(18));
+        Assert.Equal(0, _rules.AbilityMod(10));
+    }
+
+    [Fact]
+    public void Saves_GoodAndPoorProgression()
+    {
+        var c = CreateBaseCharacter();
+        var saves = _rules.Saves(c);
+        Assert.Equal(3 + _rules.AbilityMod(10), saves.Fort); // Base save 3 for level3 good
+        Assert.Equal(1 + _rules.AbilityMod(10), saves.Ref);  // Base save 1 for level3 poor
+        Assert.Equal(1 + _rules.AbilityMod(10), saves.Will); // same as reflex
+    }
+
+    [Fact]
+    public void SkillTotal_IncludesArmorCheckPenalty()
+    {
+        var c = CreateBaseCharacter();
+        c.Abilities.Dex = 12;
+        c.Ac.ArmorCheckPenalty = -1;
+        var skill = new Skill { Name = "Balance", Ability = Ability.Dex, Ranks = 2, ArmorCheckApplies = true, IsClassSkill = true };
+        Assert.Equal(2, _rules.SkillTotal(c, skill)); // 2 ranks +1 dex -1 acp
+    }
+
+    [Fact]
+    public void Encumbrance_HeavyWhenOverMedium()
+    {
+        var c = CreateBaseCharacter();
+        c.Abilities.Str = 10; // light 33 medium 66 heavy100
+        c.Inventory.Add(new InventoryItem { Name = "Rocks", Qty = 1, Weight = 70 });
+        var enc = _rules.Encumbrance(c);
+        Assert.Equal(LoadCategory.Heavy, enc.Category);
+    }
+}

--- a/dnd3.5App.Tests/dnd3.5App.Tests.csproj
+++ b/dnd3.5App.Tests/dnd3.5App.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>dnd3._5App.Tests</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dnd3.5App.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dnd3.5App.csproj
+++ b/dnd3.5App.csproj
@@ -9,6 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.19" PrivateAssets="all" />
+    <PackageReference Include="TG.Blazor.IndexedDB" Version="1.5.0-preview" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="dnd3.5App.Tests/**/*.cs" />
   </ItemGroup>
 
 </Project>

--- a/dnd3.5App.sln
+++ b/dnd3.5App.sln
@@ -1,8 +1,10 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dnd3.5App", "dnd3.5App.csproj", "{0DF845A0-2585-CB27-5CD7-28B4DE043279}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dnd3.5App.Tests", "dnd3.5App.Tests\dnd3.5App.Tests.csproj", "{9702EF86-3E4F-4A3C-894C-68C6AFBD14DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,6 +16,10 @@ Global
 		{0DF845A0-2585-CB27-5CD7-28B4DE043279}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0DF845A0-2585-CB27-5CD7-28B4DE043279}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0DF845A0-2585-CB27-5CD7-28B4DE043279}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9702EF86-3E4F-4A3C-894C-68C6AFBD14DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9702EF86-3E4F-4A3C-894C-68C6AFBD14DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9702EF86-3E4F-4A3C-894C-68C6AFBD14DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9702EF86-3E4F-4A3C-894C-68C6AFBD14DE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,0 +1,10 @@
+body {
+    background-color: #fdf6e3;
+    color: #222;
+    font-family: sans-serif;
+    margin: 0;
+    padding: 0;
+}
+.abilities, .saves, .ac, .weapons, .skills, .money {
+    margin-bottom: 1rem;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -8,6 +8,7 @@
     <base href="/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="css/site.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="dnd3.5App.styles.css" rel="stylesheet" />
 </head>

--- a/wwwroot/sample-data/fighter.json
+++ b/wwwroot/sample-data/fighter.json
@@ -1,0 +1,41 @@
+{
+  "id": "fighter-1",
+  "name": "Borin",
+  "race": "Human",
+  "classLevels": [
+    {
+      "className": "Fighter",
+      "level": 1,
+      "babProgression": "Full",
+      "saveProgression": { "fort": "Good", "ref": "Poor", "will": "Poor" }
+    }
+  ],
+  "alignment": "NG",
+  "size": "Medium",
+  "deity": "",
+  "speedBase": 30,
+  "abilities": { "str": 16, "dex": 12, "con": 14, "int": 10, "wis": 10, "cha": 8 },
+  "abilityTempMods": { "str": 0, "dex": 0, "con": 0, "int": 0, "wis": 0, "cha": 0 },
+  "hp": { "rolled": [10], "bonusPerLevel": 0, "misc": 0, "current": 10, "nonlethal": 0 },
+  "ac": { "armorBonus": 4, "shieldBonus": 0, "naturalArmor": 0, "deflection": 0, "dodge": 0, "misc": 0, "armorCheckPenalty": -2, "maxDex": 4 },
+  "initiativeMisc": 0,
+  "savesMisc": { "fort": 0, "ref": 0, "will": 0 },
+  "attacks": [
+    { "name": "Melee", "weapon": "Longsword", "enhancement": 0, "damage": "1d8+STR", "crit": "19-20/x2", "rangeIncrement": null }
+  ],
+  "grappleMisc": 0,
+  "skills": [
+    { "name": "Balance", "ability": "Dex", "ranks": 0, "misc": 0, "armorCheckApplies": true, "isClassSkill": false },
+    { "name": "Climb", "ability": "Str", "ranks": 0, "misc": 0, "armorCheckApplies": true, "isClassSkill": true }
+  ],
+  "feats": [ { "name": "Power Attack", "notes": "" } ],
+  "traits": [],
+  "classFeatures": [ { "name": "Bonus Feat", "uses": 0, "notes": "" } ],
+  "languages": ["Common"],
+  "equipment": [ { "name": "Chain Shirt", "qty": 1, "weight": 25, "slot": "armor", "acBonus": 4, "armorCheckPenalty": -2, "maxDex": 4 } ],
+  "inventory": [ { "name": "Rations", "qty": 5, "weight": 1 } ],
+  "money": { "cp": 0, "sp": 0, "gp": 100, "pp": 0 },
+  "encumbrance": { "carryCapacityOverride": null },
+  "spells": { "casterEntries": [] },
+  "notes": ""
+}


### PR DESCRIPTION
## Summary
- add strongly typed character, class, and spell models
- implement RulesService for ability mods, saves, skills and encumbrance
- scaffold pages and components to display character stats
- persist characters with IndexedDB-backed StorageService and seed fighter example
- add unit tests for core rules calculations

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b24e7cb6083248d18368323098623